### PR TITLE
feat: add supabase data layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,19 @@ Sistema-Disciplinar-Jupiara/
 | `NODE_ENV` | Ambiente (development/production) | Não |
 | `DEBUG_ENABLED` | Habilitar debug | Não |
 
+## Supabase
+
+Crie um arquivo `config.js` baseado em `config.example.js` na raiz do projeto. Ele deve definir as chaves:
+
+```js
+window.__ENV = {
+  SUPABASE_URL: "https://...supabase.co",
+  SUPABASE_ANON_KEY: "..."
+};
+```
+
+O arquivo `config.js` não deve ser commitado.
+
 ## 📞 Suporte
 
 ### Problemas Comuns

--- a/config.example.js
+++ b/config.example.js
@@ -1,0 +1,4 @@
+window.__ENV = {
+  SUPABASE_URL: "https://...supabase.co",
+  SUPABASE_ANON_KEY: "..."
+};

--- a/scripts/dataAdapter.supabase.js
+++ b/scripts/dataAdapter.supabase.js
@@ -1,0 +1,58 @@
+import { supabase } from './supabaseClient.js';
+
+// === Alunos ===
+export async function fetchAlunos({ turma=null, search=null, page=1, pageSize=25 }={}) {
+  let q = supabase.from('alunos').select(`
+    "código (matrícula)",
+    "Nome completo",
+    turma,
+    responsável,
+    "Telefone do responsável",
+    "Telefone do responsável 2"
+  `, { count: 'exact' });
+
+  if (turma) q = q.eq('turma', turma);
+  if (search) q = q.ilike('Nome completo', `%${search}%`);
+
+  q = q.order('Nome completo', { ascending: true });
+
+  const from = (page-1)*pageSize, to = from+pageSize-1;
+  const { data, error, count } = await q.range(from, to);
+
+  if (error) { console.error('[fetchAlunos]', error); return { data:[], error, count:0 }; }
+  return { data, error:null, count };
+}
+
+// === Medidas ===
+export async function fetchMedidas({ codigo_matricula=null, turma=null, dataDe=null, dataAte=null, page=1, pageSize=25 }={}) {
+  let q = supabase.from('medidas').select('*', { count: 'exact' });
+
+  if (codigo_matricula) q = q.eq('codigo_matricula', codigo_matricula);
+  if (turma) q = q.eq('turma', turma);
+  if (dataDe) q = q.gte('data', dataDe);
+  if (dataAte) q = q.lte('data', dataAte);
+
+  q = q.order('data', { ascending:false });
+
+  const from = (page-1)*pageSize, to = from+pageSize-1;
+  const { data, error, count } = await q.range(from, to);
+
+  if (error) { console.error('[fetchMedidas]', error); return { data:[], error, count:0 }; }
+  return { data, error:null, count };
+}
+
+// === Frequência ===
+export async function fetchFrequencia({ turma=null, data=null, page=1, pageSize=25 }={}) {
+  let q = supabase.from('frequencia').select('*', { count:'exact' });
+
+  if (turma) q = q.eq('turma', turma);
+  if (data) q = q.eq('data', data);
+
+  q = q.order('data', { ascending:false });
+
+  const from = (page-1)*pageSize, to = from+pageSize-1;
+  const { data, error, count } = await q.range(from, to);
+
+  if (error) { console.error('[fetchFrequencia]', error); return { data:[], error, count:0 }; }
+  return { data, error:null, count };
+}

--- a/scripts/dataService.js
+++ b/scripts/dataService.js
@@ -1,0 +1,5 @@
+export {
+  fetchAlunos as listAlunos,
+  fetchMedidas as listMedidasDisciplinares,
+  fetchFrequencia as listFrequencia
+} from './dataAdapter.supabase.js';

--- a/scripts/supabaseClient.js
+++ b/scripts/supabaseClient.js
@@ -1,0 +1,6 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+const env = (window.__ENV||{});
+if(!env.SUPABASE_URL||!env.SUPABASE_ANON_KEY){
+  console.warn("Supabase env ausente em config.js");
+}
+export const supabase = createClient(env.SUPABASE_URL, env.SUPABASE_ANON_KEY);


### PR DESCRIPTION
## Summary
- add Supabase client and adapter for alunos, medidas and frequencia
- document how to configure Supabase env vars

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b20aa509d4832c8387633e8754c8fc